### PR TITLE
Using proper directory name case to check module domains

### DIFF
--- a/Config/module.xml
+++ b/Config/module.xml
@@ -20,7 +20,7 @@
         <language>en_US</language>
         <language>fr_FR</language>
     </languages>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
     <authors>
         <author>
             <name>Vincent Lopes-Vicente, Nicolas Barbey</name>

--- a/Controller/ExportController.php
+++ b/Controller/ExportController.php
@@ -250,8 +250,16 @@ class ExportController extends BaseAdminController
     {
         $modulesNames = scandir(THELIA_LOCAL_DIR.'modules'.DS);
         $directories = [];
-        $types = [ 'Core', 'FrontOffice', 'BackOffice', 'Email', 'Pdf'];
+        $types = [
+            'core' => 'Core',
+            'frontOffice' => 'FrontOffice',
+            'backOffice'  => 'BackOffice',
+            'email' => 'Email',
+            'pdf' => 'Pdf'
+        ];
+
         $domain = null;
+
         foreach ($modulesNames as $moduleName){
             if ($moduleName[0] !== '.'){
                 /** @var Module $module */
@@ -261,12 +269,12 @@ class ExportController extends BaseAdminController
                     continue;
                 }
 
-                foreach ($types as $type){
+                foreach ($types as $dirName => $type){
                     $getDomainFunction = 'get'.$type.'TemplateTranslationDomain';
                     $getPathFunction = 'getAbsolute'.$type.'TemplatePath';
                     $templateNames = [];
-                    if (file_exists($module->getAbsoluteBaseDir().DS.'templates'.DS.$type)){
-                        $templateNames = $this->getTemplateNames($module->getAbsoluteBaseDir().DS.'templates'.DS.$type);
+                    if (file_exists($module->getAbsoluteBaseDir().DS.'templates'.DS.$dirName)){
+                        $templateNames = $this->getTemplateNames($module->getAbsoluteBaseDir().DS.'templates'.DS.$dirName);
                     }
 
                     if ($type === 'Core') {
@@ -286,6 +294,7 @@ class ExportController extends BaseAdminController
                 }
             }
         }
+
         return $directories;
     }
 

--- a/Controller/ExportController.php
+++ b/Controller/ExportController.php
@@ -270,17 +270,17 @@ class ExportController extends BaseAdminController
                 }
 
                 foreach ($types as $dirName => $type){
-                    $getDomainFunction = 'get'.$type.'TemplateTranslationDomain';
-                    $getPathFunction = 'getAbsolute'.$type.'TemplatePath';
-                    $templateNames = [];
-                    if (file_exists($module->getAbsoluteBaseDir().DS.'templates'.DS.$dirName)){
-                        $templateNames = $this->getTemplateNames($module->getAbsoluteBaseDir().DS.'templates'.DS.$dirName);
-                    }
-
                     if ($type === 'Core') {
                         $getDomainFunction = 'getTranslationDomain';
                         $getPathFunction = 'getAbsoluteBaseDir';
                         $templateNames[] = $type;
+                    } else {
+                        $getDomainFunction = 'get'.$type.'TemplateTranslationDomain';
+                        $getPathFunction = 'getAbsolute'.$type.'TemplatePath';
+                        $templateNames = [];
+                        if (file_exists($module->getAbsoluteBaseDir().DS.'templates'.DS.$dirName)){
+                            $templateNames = $this->getTemplateNames($module->getAbsoluteBaseDir().DS.'templates'.DS.$dirName);
+                        }
                     }
 
                     foreach ($templateNames as $templateName){


### PR DESCRIPTION
The existence of templates directories in modules were checked with a Pascal case string (e.g. `FrontOffice`) instead of a camel case string (e.g. `frontOffice`). 

For example, `/home/www/local/modules/HookCart/templates/FrontOffice` was searched.

This is working on MacOS or Windows, but not on Unix systems.